### PR TITLE
ft: adding career pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist/
 .env.production.local
 
 /.autogit
+/.history
+.history

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "apollo-server": "^2.2.3",
     "apollo-server-express": "^2.2.3",
+    "bcrypt": "^3.0.8",
     "chai": "^4.2.0",
     "cors": "^2.8.5",
     "dataloader": "^1.4.0",

--- a/src/controllers/career.controller.js
+++ b/src/controllers/career.controller.js
@@ -1,0 +1,83 @@
+import CareerService from '../services/Career.Service';
+import response from '../helpers/response';
+
+class CareerController {
+	static async createCareer(req, res) {
+		const createdCareer = await CareerService.createCareer({
+			department: req.body.department,
+			jobTitle: req.body.jobTitle,
+			location: req.body.location,
+			jobLink: req.body.jobLink,
+		});
+
+		return response.successMessage(
+			res,
+			'Career is successfully created',
+			201,
+			createdCareer
+		);
+	}
+
+	static async getOpenCareer(req, res) {
+		const openCarrers = await CareerService.getCareersByAttribute({
+			isOpen: true,
+		});
+		if (Object.keys(openCarrers).length !== 0) {
+			const careersToDisplay = Object.entries(openCarrers).map(
+				([key, career]) => {
+					const { createdAt, updatedAt, ...careersElement } = career.dataValues;
+					return careersElement;
+				}
+			);
+
+			const groupedCareers = careersToDisplay.reduce((acc, obj) => {
+				const key = obj.department;
+				if (!acc[key]) {
+					acc[key] = [];
+				}
+				acc[key].push(obj);
+				return acc;
+			}, {});
+			const groupedCareersToDisplay = Object.entries(groupedCareers).map(
+				([key, career]) => ({ department: key, depRoles: career })
+			);
+			return response.successMessage(
+				res,
+				'Careers retrieved successfully',
+				200,
+				groupedCareersToDisplay
+			);
+		}
+		return response.errorMessage(
+			res,
+			'Sorry no open careers at the moments',
+			404
+		);
+	}
+
+  static updateCareer = async (req, res) => {
+  	if (parseInt(req.params.id)) {
+  		const careerExist = await CareerService.findCareerByAttribute({ id: req.params.id });
+  		if (careerExist) {
+  			await CareerService.updateCareerByAttribute(
+  				{ id: req.params.id },
+  				req.body
+  			);
+  			return response.successMessage(
+  				res,
+  				'Career updated successfully',
+  				200
+
+  			);
+  		}
+  		return response.errorMessage(
+  			res,
+  			`Career with id ${req.params.id} does not exist`,
+  			404
+  		);
+  	}
+  	return response.errorMessage(res, 'Invalid id supplied', 422);
+  };
+}
+
+export default CareerController;

--- a/src/database/migrations/20210118133947-create-careers.js
+++ b/src/database/migrations/20210118133947-create-careers.js
@@ -1,0 +1,41 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('careers', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      department: {
+        type: Sequelize.STRING
+      },
+      jobTitle: {
+        type: Sequelize.STRING
+      },
+      location: {
+        type: Sequelize.STRING
+      },
+      isOpen: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: true,
+        allowNull: true
+      },
+      jobLink: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('careers');
+  }
+};

--- a/src/database/models/careers.js
+++ b/src/database/models/careers.js
@@ -1,0 +1,28 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+  class careers extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  careers.init(
+    {
+      department: DataTypes.STRING,
+      jobTitle: DataTypes.STRING,
+      location: DataTypes.STRING,
+      isOpen: { type: DataTypes.BOOLEAN, allowNull: true, defaultValue: true },
+      jobLink: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: "careers",
+    }
+  );
+  return careers;
+};

--- a/src/helpers/validate.js
+++ b/src/helpers/validate.js
@@ -11,15 +11,15 @@ class Validate {
 				.isLength({ min: 3 }),
 			check(
 				'email',
-				'Invalid email address, example: example@gmail.com.',
+				'Invalid email address, example: example@gmail.com.'
 			).isEmail(),
 			check(
 				'password',
-				'Password should be provided and must be alphanumeric with atleast 8 charactors.',
+				'Password should be provided and must be alphanumeric with atleast 8 charactors.'
 			).isLength({ min: 8 }),
 			check(
 				'primaryLanguageId',
-				'primaryLanguageId should be valide',
+				'primaryLanguageId should be valide'
 			).isNumeric(),
 		];
 	}
@@ -28,11 +28,11 @@ class Validate {
 		return [
 			check(
 				'email',
-				'Invalid email address, example: example@gmail.com.',
+				'Invalid email address, example: example@gmail.com.'
 			).isEmail(),
 			check(
 				'password',
-				'Invalid password, your password should be alphanumeric with atleast 8 charactors.',
+				'Invalid password, your password should be alphanumeric with atleast 8 charactors.'
 			).isLength({ min: 8 }),
 		];
 	}
@@ -41,17 +41,14 @@ class Validate {
 		return [
 			check(
 				'email',
-				'Invalid email address, example: example@gmail.com.',
+				'Invalid email address, example: example@gmail.com.'
 			).isEmail(),
 		];
 	}
 
 	static userRole() {
 		return [
-			check(
-				'role',
-				'Invalid User Role.',
-			).isString().isLength({ min: 2 }),
+			check('role', 'Invalid User Role.').isString().isLength({ min: 2 }),
 		];
 	}
 
@@ -60,7 +57,7 @@ class Validate {
 			check('name', 'name should be valid.').isString().isLength({ min: 2 }),
 			check(
 				'email',
-				'Invalid email address, example: example@gmail.com.',
+				'Invalid email address, example: example@gmail.com.'
 			).isEmail(),
 			check('message', 'message must be provided.')
 				.isString()
@@ -93,7 +90,6 @@ class Validate {
 			check('rootCourseId', 'Invalid rootCourseId').isNumeric(),
 			check('chapter', 'chapter must be a valid chapter number').isNumeric(),
 			check('content', 'content must be provided').isLength({ min: 1 }),
-
 		];
 	}
 
@@ -105,15 +101,11 @@ class Validate {
 	}
 
 	static music() {
-		return [
-			check('music', 'music link is required').isLength({ min: 1 }),
-		];
+		return [check('music', 'music link is required').isLength({ min: 1 })];
 	}
 
 	static video() {
-		return [
-			check('video', 'video link is required').isLength({ min: 1 }),
-		];
+		return [check('video', 'video link is required').isLength({ min: 1 })];
 	}
 
 	static dailyWord() {
@@ -125,6 +117,28 @@ class Validate {
 	static getDailyWord() {
 		return [
 			check('languageKey', 'languageKey is required').isLength({ min: 1 }),
+		];
+	}
+
+	static career() {
+		return [
+			check('department', 'department is invalid.')
+				.isString()
+				.isLength({ min: 3 })
+				.notEmpty(),
+			check('jobTitle', 'jobTitle is invalid.')
+				.isString()
+				.isLength({ min: 3 })
+				.notEmpty(),
+			check('location', 'location should be a valid location.')
+				.isString()
+				.isLength({ min: 3 })
+				.not()
+				.isEmpty(),
+			check('jobLink', 'jobLink is invalid!')
+				.isString()
+				.isLength({ min: 3 })
+				.notEmpty(),
 		];
 	}
 }

--- a/src/routes/career.routes.js
+++ b/src/routes/career.routes.js
@@ -1,0 +1,26 @@
+import CareerController from "../controllers/career.controller";
+import { Router } from "express";
+import Validate from "../helpers/validate";
+import isValid from "../middlewares/validate";
+import verifyToken from "../middlewares/verifyToken";
+import verifyAdmin from "../middlewares/verify.admin";
+
+const router = Router();
+
+router.get("/", CareerController.getOpenCareer);
+router.post(
+  "/",
+  verifyToken.headerToken,
+  verifyAdmin,
+  Validate.career(),
+  isValid,
+  CareerController.createCareer
+);
+router.patch(
+  "/:id",
+  verifyToken.headerToken,
+  verifyAdmin,
+  CareerController.updateCareer
+);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,6 +10,7 @@ import languageRouter from './language';
 import addCourseTranslate from './addCourses.routes';
 import addContents from './addContents.routes';
 import dailyWord from './dailyWord';
+import careerRoute from './career.routes';
 
 const Router = express.Router();
 Router.use('/auth', userRoute);
@@ -23,5 +24,6 @@ Router.use('/content', contentRoute);
 Router.use('/add-courses', addCourseTranslate);
 Router.use('/add-contents', addContents);
 Router.use('/dailyWord', dailyWord);
+Router.use('/career', careerRoute);
 
 export default Router;

--- a/src/services/Career.Service.js
+++ b/src/services/Career.Service.js
@@ -1,0 +1,34 @@
+import models from "../database/models";
+
+const { careers } = models;
+
+/**
+ * This a class dealing with careers
+ */
+class CareerService {
+  /**
+   * @param {object} career
+   * @returns {object} create a career object
+   */
+  static createCareer = (career) => {
+    return careers.create(career);
+  };
+
+  /**
+   * @param {object} attribute
+   * @returns {object} get all careers
+   */
+  static getCareersByAttribute = (attribute) => {
+    return careers.findAll({ where: attribute });
+  };
+
+  static updateCareerByAttribute = (attribute, payload) => {
+    return careers.update(payload, { where: attribute })
+  }
+
+  static findCareerByAttribute = (attribute) => {
+    return careers.findOne({ where: attribute });
+  };
+}
+
+export default CareerService;


### PR DESCRIPTION
#### What does this PR do?
* create career
* get careers
* update a career
#### Description of Task to be completed?
* Admin should be able to add open roles in company
* As a user I should be able to view all open roles in back-end
* Admin is able to edit career
#### How should this be manually tested?
* clone this repo by running `git clone https://github.com/Soma-Technologies-Inc/somafri-backend.git`
* run `cd somafri-backend`
* run `git checkout ft-adding-carrer-page` in order to navigate to this branch :relaxed:
* run `git pull` in order to have updated code from this **branch**
* create a **.env** file by running `touch .env` and put all environment variables there using **.envexamples file**
* run `npm install` to install all the dependencies
* run `npm run migrate` to migrate datas and tables in the database
* run `npm run dev-start` to start the server
* then  navigate to `http://localhost:10000/graphql` to start login with admin user and get token by using mutation like this `mutation {
  loginUser(email: "youremail@domain.com", password: "graphql") {
    token
  }
}`
* then copy the `token` you will get in response then navigate to `POST /soma/career` to create a career , set authorization header `token` add value `bearer` and **token you got while login with admin user**,.... send body data like this `{
	"department": "Software",
	"jobTitle": "Cooking",
	"location": "England",
	"isOpen": "true",
	"jobLink": "https://chica.com"
}`
* create as many as you want
* then get all open career offers by navigating to `GET /soma/career` :fire:
#### Any background context you want to provide?
#### Screenshots (if appropriate)
