### PR TITLE
FIx:Get user course contents

### DIFF
--- a/src/database/migrations/20200904062244-create-track-course.js
+++ b/src/database/migrations/20200904062244-create-track-course.js
@@ -42,6 +42,9 @@ module.exports = {
 		courseComplexity: {
 			type: Sequelize.INTEGER,
 		},
+		testResult: {
+			type: Sequelize.INTEGER,
+		},
 		levelCourses: {
 			type: Sequelize.INTEGER,
 		},

--- a/src/database/models/trackcourse.js
+++ b/src/database/models/trackcourse.js
@@ -10,7 +10,7 @@ module.exports = (sequelize, DataTypes) => {
 		translatedCourseName: DataTypes.STRING,
 		currentChapter: DataTypes.INTEGER,
 		totalChapter: DataTypes.INTEGER,
-		testResult: DataTypes.INTEGER,
+		// testResult: DataTypes.INTEGER,
 
 	}, {});
 	trackCourses.associate = function (models) {

--- a/src/resolvers/language.resolvers.js
+++ b/src/resolvers/language.resolvers.js
@@ -124,7 +124,6 @@ const languageResolvers = {
 				if (getLanguage === null) {
 					throw new UserInputError('The language doesnt exist');
 				}
-
 				const { id: languageId } = getLanguage;
 				const checkIfEnrolled = await LanguageServices.checkIfUserAlreadyEnrolled(
 					languageId,
@@ -145,13 +144,18 @@ const languageResolvers = {
 					currentLevel,
 					totalLevel,
 					countryFlag,
+					currentCourseId: getLanguageCourses.rows[0].dataValues.id,
+					currentCourseName: getLanguageCourses.rows[0].dataValues.name,
 				};
 				const enrolledLanguage = await LanguageServices.enrollToLanguage(data);
+
 				const responseData = {
 					id: enrolledLanguage.id,
 					userId,
 					currentLevel,
+					languageId,
 					totalLevel,
+					LanguageName:findLanguage.name,
 					enrolledLanguage: findLanguage.name,
 					countryFlag,
 					updatedAt: enrolledLanguage.updatedAt,

--- a/src/schema/course.schema.js
+++ b/src/schema/course.schema.js
@@ -86,6 +86,7 @@ export default gql`
     primaryLanguageContents: primaryLanguageContents
   }
   type courseContents {
+    currentChapter: Int
     rootContent: [rootContent]
     contentData: [contentData]
   }
@@ -114,6 +115,7 @@ export default gql`
     getCoursesByLevel(levelId: Int!): [course!]!
     getLanguageCourses(languageId: Int!): [languageCourses!]!
     getCourseContents(languageId: Int!, courseId: Int!): courseContents!
+    getUserLearningCourseContents(languageId: Int!, courseId: Int!): courseContents!
     getUserCourseContents(
       languageId: Int!
       courseId: Int!

--- a/src/services/courses.js
+++ b/src/services/courses.js
@@ -31,6 +31,7 @@ class CoursesServices {
 				where: {
 					[Op.and]: [{ id }, { languageId }],
 				},
+				
 			});
 		} catch (error) {
 			return null;

--- a/src/services/trackCourse.js
+++ b/src/services/trackCourse.js
@@ -24,6 +24,7 @@ class TrackCourse {
 	}
 
 	static async findCourseByLanguageId(userId, languageId, courseId) {
+
 		try {
 			return await db.trackCourses.findOne({
 				where: {
@@ -31,7 +32,8 @@ class TrackCourse {
 				},
 			});
 		} catch (error) {
-			return null;
+
+			return error;
 		}
 	}
 


### PR DESCRIPTION
#### What does this PR do?
- Get user course contents
#### Description of Task to be completed?
- User should be able to get course contents based on his/her primary  language
#### How should this be manually tested?
- clone the [repo](https://github.com/Soma-Technologies-Inc/somafri-backend.git)
- run `cd somafri-backend` to enter in the repo
- `create a Postgres database`
- create a `.env` file and use .env.example as its blueprint.
- run the` git fetch` command to download commits, files, and refs from a remote repository into your local repo.
- run `git checkout  chore-fix-user-course-contents ` to access this branch.
- run `npm i` to install dependencies.
- run `npm run migrate` to create tables in your database.
- run `npm run dev-start` to start the development server.
      use the bellow graphql query to get course contents
```
query{
getUserLearningCourseContents(languageId:2, courseId:1){
  currentChapter,
  rootContent{
    rootCourseId,
    chapter,
    content,
    contentImage,
    contentAudio
  },
  contentData{
   rootContentId,
    languageId,
    content,
    contentAudio
    
  }
}
}
```
#### Any background context you want to provide?
#### Screenshots (if appropriate)
![Screenshot from 2021-02-02 23-36-12](https://user-images.githubusercontent.com/52497006/106666050-bda01800-65af-11eb-8c19-0e788062ad90.png)


#### Questions:
